### PR TITLE
[TASK] Adapt slot signature for CMS 7

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,9 +5,18 @@ if (!defined('TYPO3_MODE')) {
 
 require_once \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('site', 'volatileinstaller.php');
 
-\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher')->connect(
-	'TYPO3\\CMS\\Extensionmanager\\Controller\\ConfigurationController',
-	'afterExtensionConfigurationWrite',
-	'VolatileInstaller',
-	'process'
-);
+if ('6.2' === TYPO3_branch) {
+	\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher')->connect(
+		'TYPO3\\CMS\\Extensionmanager\\Controller\\ConfigurationController',
+		'afterExtensionConfigurationWrite',
+		'VolatileInstaller',
+		'processForSixTwo'
+	);
+} else {
+	\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher')->connect(
+		'TYPO3\\CMS\\Extensionmanager\\Controller\\ConfigurationController',
+		'afterExtensionConfigurationWrite',
+		'VolatileInstaller',
+		'process'
+	);
+}

--- a/volatileinstaller.php
+++ b/volatileinstaller.php
@@ -54,11 +54,30 @@ class VolatileInstaller {
 	protected $settings = array();
 
 	/**
+	 * @param string $extensionKey
 	 * @param array $settings
 	 * @param \TYPO3\CMS\Extensionmanager\Controller\ConfigurationController $controller
 	 * @return void
 	 */
-	public function process(array $settings, \TYPO3\CMS\Extensionmanager\Controller\ConfigurationController $controller) {
+	public function process($extensionKey, array $settings, \TYPO3\CMS\Extensionmanager\Controller\ConfigurationController $controller) {
+		$this->doProcess($settings, $controller);
+	}
+
+	/**
+	 * @param array $settings
+	 * @param \TYPO3\CMS\Extensionmanager\Controller\ConfigurationController $controller
+	 * @return void
+	 */
+	public function processForSixTwo(array $settings, \TYPO3\CMS\Extensionmanager\Controller\ConfigurationController $controller) {
+		$this->doProcess($settings, $controller);
+	}
+
+	/**
+	 * @param array $settings
+	 * @param \TYPO3\CMS\Extensionmanager\Controller\ConfigurationController $controller
+	 * @return void
+	 */
+	protected function doProcess(array $settings, \TYPO3\CMS\Extensionmanager\Controller\ConfigurationController $controller) {
 		$this->settings = $this->remapSettings($settings);
 		if (TRUE === isset($this->settings['kickstart']) && TRUE === (boolean) $this->settings['kickstart']) {
 			if (TRUE === \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($this->settings['extensionKey'])) {


### PR DESCRIPTION
There is a change in the signature of the dispatched Signal 'afterExtensionConfigurationWrite' in CMS 7. An additional parameter $extensionKey comes in as first one.

see: https://git.typo3.org/Packages/TYPO3.CMS.git/commit/2fc3ec6b9c8550dc9cb606a74dcf52d8ae22b3d7
